### PR TITLE
Correctly resolve user styles on top of defaults.

### DIFF
--- a/src/draw.typ
+++ b/src/draw.typ
@@ -251,21 +251,20 @@
         style.label.insert("text", inputs.map(str).join(","))
       }
 
+      // resolve loop styles on top
+      if from == to {
+        style = cetz.styles.resolve(
+          ctx.style.at("loop", default: (:)),
+          merge: style
+        )
+      }
+
       let style = cetz.styles.resolve(
         ctx.style,
         merge: style,
         base: util.default-style.transition,
         root: "transition",
       )
-      // resolve loop styles on top
-      if from == to {
-        style = cetz.styles.resolve(
-          ctx.style,
-          merge: ctx.style.at("loop", default: (:)),
-          base: style,
-          root: "transition",
-        )
-      }
 
       let (_, start, f-center, f-right, end, t-center, t-right) = cetz.coordinate.resolve(
         ctx,


### PR DESCRIPTION
Fixed the below code, which obscures styling options of individual loops if the user has set either `transition` or `loop` in the style.
```
      // resolve loop styles on top
      if from == to {
        style = cetz.styles.resolve(
          ctx.style,
          merge: ctx.style.at("loop", default: (:)),
          base: style,
          root: "transition",
        )
      }
```